### PR TITLE
Implement and document Discord message sending operator

### DIFF
--- a/docs/discord_message_sender.md
+++ b/docs/discord_message_sender.md
@@ -1,21 +1,16 @@
 # Summary
-
 The `DiscordMessageSender` operator sends a message using Discord API with the specified message content and channel ID.
 
 # Inputs
-
--   `message_content`: A string containing the message content to be sent.
+- `message_content`: A string containing the message content to be sent.
 
 # Parameters
-
--   `channel_id`: A string representing the channel's ID where the message will be sent.
+- `channel_id`: A string representing the channel's ID where the message will be sent.
 
 # Outputs
-
--   `message_status`: A string indicating the status of the message sending process, either "Message sent successfully" or "Message sending failed".
+- `message_status`: A string indicating the status of the message sending process, either "Message sent successfully" or "Message sending failed".
 
 # Functionality
-
 The `run_step` function is responsible for the main logic of the operator. It reads the channel ID from the parameters, and the message content from the inputs. It also retrieves the Discord bot API token from the AI context. It then calls the `send_message` helper function with the necessary parameters to send the message.
 
 The `send_email` function configures the headers and data of the post request by formatting the parameters and inputs accordingly and sends the message to the channel. It returns the status of the message sending process as a string.

--- a/docs/discord_message_sender.md
+++ b/docs/discord_message_sender.md
@@ -1,0 +1,21 @@
+# Summary
+
+The `DiscordMessageSender` operator sends a message using Discord API with the specified message content and channel ID.
+
+# Inputs
+
+-   `message_content`: A string containing the message content to be sent.
+
+# Parameters
+
+-   `channel_id`: A string representing the channel's ID where the message will be sent.
+
+# Outputs
+
+-   `message_status`: A string indicating the status of the message sending process, either "Message sent successfully" or "Message sending failed".
+
+# Functionality
+
+The `run_step` function is responsible for the main logic of the operator. It reads the channel ID from the parameters, and the message content from the inputs. It also retrieves the Discord bot API token from the AI context. It then calls the `send_message` helper function with the necessary parameters to send the message.
+
+The `send_email` function configures the headers and data of the post request by formatting the parameters and inputs accordingly and sends the message to the channel. It returns the status of the message sending process as a string.

--- a/docs/discord_message_sender.md
+++ b/docs/discord_message_sender.md
@@ -2,15 +2,19 @@
 The `DiscordMessageSender` operator sends a message using the Discord API with the specified message content and channel ID.
 
 # Inputs
-- `message_content`: A string containing the message content to be sent.
+- `message_content`: A string containing the message content to be sent. Optional if an embed is provided.
+- `embed_title`: A string containing the title of the embed message. Optional.
+- `embed_description`: A string containing the description of the embed message. Optional.
+- `embed_fields`: A list of dictionaries containing the names and values of the fields of the embed. Optional.
 
 # Parameters
 - `channel_id`: A string representing the channel's ID where the message will be sent.
+- `embed_color`: A string representing the color of the embed message as a hex code. Optional.
 
 # Outputs
 - `message_status`: A string indicating the status of the message sending process, either "Message sent successfully" or "Message sending failed".
 
 # Functionality
-The `run_step` function is responsible for the main logic of the operator. After reading the channel ID from the parameters and the message content from the inputs, this function retrieves the Discord bot API token from the AI context and calls the `send_message` helper function with the necessary parameters to send the message.
+The `run_step` function is responsible for the main logic of the operator. First, it reads the channel ID and embed color from the parameters. Next, it reads the message content and the embed options from the input. Then, this function retrieves the Discord bot API token from the AI context and calls the `send_message` helper function with the necessary parameters to send the message.
 
 The `send_message` function configures the headers and data of the post request by formatting the parameters and inputs accordingly, and sends the message to the channel. It returns the status of the message sending process as a string.

--- a/docs/discord_message_sender.md
+++ b/docs/discord_message_sender.md
@@ -1,5 +1,5 @@
 # Summary
-The `DiscordMessageSender` operator sends a message using Discord API with the specified message content and channel ID.
+The `DiscordMessageSender` operator sends a message using the Discord API with the specified message content and channel ID.
 
 # Inputs
 - `message_content`: A string containing the message content to be sent.
@@ -11,6 +11,6 @@ The `DiscordMessageSender` operator sends a message using Discord API with the s
 - `message_status`: A string indicating the status of the message sending process, either "Message sent successfully" or "Message sending failed".
 
 # Functionality
-The `run_step` function is responsible for the main logic of the operator. It reads the channel ID from the parameters, and the message content from the inputs. It also retrieves the Discord bot API token from the AI context. It then calls the `send_message` helper function with the necessary parameters to send the message.
+The `run_step` function is responsible for the main logic of the operator. After reading the channel ID from the parameters and the message content from the inputs, this function retrieves the Discord bot API token from the AI context and calls the `send_message` helper function with the necessary parameters to send the message.
 
-The `send_email` function configures the headers and data of the post request by formatting the parameters and inputs accordingly and sends the message to the channel. It returns the status of the message sending process as a string.
+The `send_message` function configures the headers and data of the post request by formatting the parameters and inputs accordingly, and sends the message to the channel. It returns the status of the message sending process as a string.

--- a/operators/discord_send_message.py
+++ b/operators/discord_send_message.py
@@ -21,6 +21,12 @@ class DiscordMessageSender(BaseOperator):
                 "data_type": "string",
                 "placeholder": "Enter the channel ID",
             },
+            {
+                "name": "embed_color",
+                "data_type": "string",
+                "placeholder": "Enter the embed color as a hex code",
+                "optional": "1",
+            },
         ]
 
     @staticmethod
@@ -29,7 +35,22 @@ class DiscordMessageSender(BaseOperator):
             {
                 "name": "message_content",
                 "data_type": "string",
-                "placeholder": "Enter the message content",
+                "optional": "1",
+            },
+            {
+                "name": "embed_title",
+                "data_type": "string",
+                "optional": "1",
+            },
+            {
+                "name": "embed_description",
+                "data_type": "string",
+                "optional": "1",
+            },
+            {
+                "name": "embed_fields",
+                "data_type": "{name, value}[]",
+                "optional": "1",
             },
         ]
 
@@ -45,25 +66,64 @@ class DiscordMessageSender(BaseOperator):
     def run_step(self, step, ai_context: AiContext):
         params: dict[str, str] = step["parameters"]
         channel_id: str = params.get("channel_id")
+        embed_color: str = params.get("embed_color")
 
         message_content: str = ai_context.get_input("message_content", self)
+        embed_title: str = ai_context.get_input("embed_title", self)
+        embed_description: str = ai_context.get_input("embed_description", self)
+        embed_fields: list[dict[str, str]] = ai_context.get_input("embed_fields", self)
+
         token: str = ai_context.get_secret("discord_bot_token")
 
         message_status = self.send_message(
-            channel_id, message_content, token, ai_context
+            channel_id,
+            message_content,
+            embed_title,
+            embed_description,
+            embed_fields,
+            embed_color,
+            token,
+            ai_context,
         )
         ai_context.set_output("message_status", message_status, self)
 
     def send_message(
-        self, channel_id: str, message_content: str, token: str, ai_context: AiContext
+        self,
+        channel_id: str,
+        message_content: str,
+        embed_title: str,
+        embed_description: str,
+        embed_fields: list[dict[str, str]],
+        embed_color: str,
+        token: str,
+        ai_context: AiContext,
     ):
         try:
+            contains_embed = any((embed_title, embed_description, embed_fields))
+            if not message_content and not contains_embed:
+                ai_context.add_to_log("No message content or embeds provided.")
+                return "Message sending failed"
+
             url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
             headers = {
                 "Authorization": f"Bot {token}",
                 "Content-Type": "application/json",
             }
+
             data = {"content": message_content}
+
+            if contains_embed:
+                embed = {}
+                if embed_title:
+                    embed["title"] = embed_title
+                if embed_description:
+                    embed["description"] = embed_description
+                if embed_fields:
+                    embed["fields"] = embed_fields
+                if embed_color:
+                    embed_color = int(embed_color.replace("#", ""), 16)
+                    embed["color"] = embed_color
+                data["embeds"] = [embed]
 
             session = requests.Session()
             response = session.post(url, headers=headers, json=data)

--- a/operators/discord_send_message.py
+++ b/operators/discord_send_message.py
@@ -65,9 +65,10 @@ class DiscordMessageSender(BaseOperator):
             }
             data = {"content": message_content}
 
-            response = requests.post(url, headers=headers, json=data)
+            session = requests.Session()
+            response = session.post(url, headers=headers, json=data)
 
-            if response.status_code == 200:
+            if 200 <= response.status_code < 300:
                 return "Message sent successfully"
             else:
                 ai_context.add_to_log(f"An error occurred: {response.text}")

--- a/operators/discord_send_message.py
+++ b/operators/discord_send_message.py
@@ -1,0 +1,77 @@
+import requests
+
+from .base_operator import BaseOperator
+from ai_context import AiContext
+
+
+class DiscordMessageSender(BaseOperator):
+    @staticmethod
+    def declare_name():
+        return "discord_send_message"
+
+    @staticmethod
+    def declare_category():
+        return BaseOperator.OperatorCategory.ACT.value
+
+    @staticmethod
+    def declare_parameters():
+        return [
+            {
+                "name": "channel_id",
+                "data_type": "string",
+                "placeholder": "Enter the channel ID",
+            },
+        ]
+
+    @staticmethod
+    def declare_inputs():
+        return [
+            {
+                "name": "message_content",
+                "data_type": "string",
+                "placeholder": "Enter the message content",
+            },
+        ]
+
+    @staticmethod
+    def declare_outputs():
+        return [
+            {
+                "name": "message_status",
+                "data_type": "string",
+            },
+        ]
+
+    def run_step(self, step, ai_context: AiContext):
+        params: dict[str, str] = step["parameters"]
+        channel_id: str = params.get("channel_id")
+
+        message_content: str = ai_context.get_input("message_content", self)
+        token: str = ai_context.get_secret("discord_bot_token")
+
+        message_status = self.send_message(
+            channel_id, message_content, token, ai_context
+        )
+        ai_context.set_output("message_status", message_status, self)
+
+    def send_message(
+        self, channel_id: str, message_content: str, token: str, ai_context: AiContext
+    ):
+        try:
+            url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
+            headers = {
+                "Authorization": f"Bot {token}",
+                "Content-Type": "application/json",
+            }
+            data = {"content": message_content}
+
+            response = requests.post(url, headers=headers, json=data)
+
+            if response.status_code == 200:
+                return "Message sent successfully"
+            else:
+                ai_context.add_to_log(f"An error occurred: {response.text}")
+                return "Message sending failed"
+        except Exception as error:
+            ai_context.add_to_log(f"An error occurred: {str(error)}")
+            return "Message sending failed"


### PR DESCRIPTION
### Summary
Implemented the `DiscordMessageSender` operator, enabling message sending to Discord channels via the Discord API.

### Documentation
Detailed comments on the implementation and usage are provided in `docs/discord_message_sender.md`.

The API documentations used were:
- https://discord.com/developers/docs/resources/channel#create-message
- https://discord.com/developers/docs/reference#api-reference-base-url

### Testing
I have tested the code as follows:
```py
import requests


def send_message(channel_id: str, message: str, token: str) -> str:
    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
    headers = {
        "Authorization": f"Bot {token}",
        "Content-Type": "application/json",
    }
    data = {"content": message}

    response = requests.post(url, headers=headers, json=data)

    if response.status_code == 200:
        return "Message sent successfully"


token = "..."
channel_id = "..."
message_content = "Hello, World"

print(send_message(channel_id, message_content, token))
```

### Notes
- Right now it sends text content only, and only to a specified channel parameter. I didn't implement embeds, images, files, etc into the message yet, or sending a message to a user, thread, etc.
- OAuth2 applications cannot send messages on behalf of users by design. This is intentional and part of Discord's security measures. Only bots can send messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new feature to send messages to Discord channels using the `DiscordMessageSender` operator. This allows users to automate message sending to specified channels through a bot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->